### PR TITLE
bugfix thresholding in micro_averaged_auprc

### DIFF
--- a/urban-sound-tagging-baseline/metrics.py
+++ b/urban-sound-tagging-baseline/metrics.py
@@ -395,7 +395,7 @@ def micro_averaged_auprc(df_dict, return_df=False):
         for coarse_id in df_dict.keys():
 
             # Find last row above threshold.
-            row = df_dict[coarse_id][df_dict[coarse_id] > threshold].iloc[-1]
+            row = df_dict[coarse_id][df_dict[coarse_id]["threshold"] >= threshold].iloc[-1]
 
             # Increment TP, FP, and FN.
             global_TP += row["TP"]


### PR DESCRIPTION
Reported by @jtcramer

(1) Comparison with the threshold needs to be done on the "threshold" Series in the df_dict DataFrame, not df_dict itself.

(2) Replace "greater" (">") by "greater than" (">=") so that it does not break on the last row of the category with the highest confidence
